### PR TITLE
Only emojify if description is defined

### DIFF
--- a/ui/Feed.js
+++ b/ui/Feed.js
@@ -66,7 +66,7 @@ const FeedEntry = ({ entry, currentUser, onVote }) => (
           {entry.repository.full_name}
         </a>
       </h4>
-      <p>{emojify(entry.repository.description)}</p>
+      <p>{entry.repository.description && emojify(entry.repository.description)}</p>
       <p>
         <InfoLabel label="Stars" value={entry.repository.stargazers_count} />
         &nbsp;


### PR DESCRIPTION
emojify requires that a string is passed in, otherwise it throws an exception trying to invoke split. Ran into this when trying to add a repository missing a description (apollostack/saturn). 