### PR TITLE
Added a production webpack build for the UI

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -44,6 +44,8 @@ app.use(passport.session());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
+app.use(express.static('dist'));
+
 app.get('/login/github',
   passport.authenticate('github'));
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint api ui",
     "test": "mocha --compilers js:babel-core/register --reporter spec --full-trace 'api/**/*.test.js' && npm run lint",
     "seed": "knex seed:run",
-    "migrate": "knex migrate:latest"
+    "migrate": "knex migrate:latest",
+    "build": "webpack -p --progress --config ./webpack.production.config.js"
   },
   "repository": {
     "type": "git",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,0 +1,39 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-source-map',
+  entry: './ui/index.js',
+  output: {
+    path: 'api/dist/',
+    publicPath: '/',
+    filename: 'bundle.js'
+  },
+  module: {
+    loaders: [{
+      test: /\.css/,
+      loader: 'style!css'
+    }, {
+      test: /\.js$/,
+      loader: 'babel',
+      exclude: /node_modules/
+    }, {
+      test: /\.json$/,
+      loader: 'json'
+    }]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify('production')
+    }
+    }),
+    new HtmlWebpackPlugin({
+      template: 'ui/index.html'
+    }),
+    new webpack.optimize.CommonsChunkPlugin('common.js'),
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.AggressiveMergingPlugin()
+  ]
+}


### PR DESCRIPTION
As mentioned in #68 

Currently the static files get served by the same Express server that the API uses - most probably not ideal but didn't want to go through the hassle of setting up CORS/proxying.

Minimizes down to 460KB from 1.7MB default webpack build. Most probably some room for improvement there as well.